### PR TITLE
Minor changes so it compiles and runs properly with the latest libraries.

### DIFF
--- a/src/GraphicsComponent.hx
+++ b/src/GraphicsComponent.hx
@@ -60,7 +60,6 @@ class GraphicsComponent extends Component {
 		particles = new ParticleSystem({name: 'attackparticles'});
 		var template:ParticleEmitterOptions = {
 			name: 'particleemitter',
-			group: 5,
 			emit_time: 0.2,
 			emit_count: 3,
 			direction: 0,

--- a/src/InputComponent.hx
+++ b/src/InputComponent.hx
@@ -84,6 +84,7 @@ class InputComponent extends Component {
 			moving = 0;
 		} // when not moving
 
+		pos = pos;
 	} //update
 
 	private function setupStateMachine(){


### PR DESCRIPTION
ParticleEmitterOptions no longer has a “group” value.

Added a line to ensure the transforms are updated when the player moves.
